### PR TITLE
XML and JSON crash

### DIFF
--- a/src/ngrok/client/views/web/http.go
+++ b/src/ngrok/client/views/web/http.go
@@ -112,8 +112,7 @@ func makeBody(h http.Header, body []byte) SerializedBody {
 	if b.RawContentType != "" {
 		b.ContentType = strings.TrimSpace(strings.Split(b.RawContentType, ";")[0])
 		switch b.ContentType {
-		case "application/xml":
-		case "text/xml":
+		case "application/xml", "text/xml":
 			err = xml.Unmarshal(body, new(XMLDoc))
 			if err != nil {
 				if syntaxError, ok := err.(*xml.SyntaxError); ok {


### PR DESCRIPTION
Right now the ngrokd client crashes when there's an empty json/xml body (or any other non-syntax error); see #7.

This fixes those.
