### PR TITLE
Adding word wrapping to path for web dashboard.

### DIFF
--- a/assets/client/page.html
+++ b/assets/client/page.html
@@ -23,7 +23,14 @@
                 background-color: #ff9999;
                 background-color: #000000;
                 color:white;
-
+            }
+            .path {
+              width: 300px;
+            }
+            .wrapped {
+              word-wrap: break-word;
+              word-break: break-word;
+              overflow: hidden;
             }
         </style>
     </head>
@@ -62,7 +69,7 @@
                     <h4>All Requests</h4>
                     <table class="table txn-selector">
                         <tr ng-controller="TxnNavItem" ng-class="{'selected':isActive()}" ng-repeat="txn in txns" ng-click="makeActive()">
-                            <td>{{ txn.Req.MethodPath }}</td>
+                            <td class="wrapped"><div class="path">{{ txn.Req.MethodPath }}</div></td>
                             <td>{{ txn.Resp.Status }}</td>
                             <td><span class="pull-right">{{ txn.Duration }}</span></td>
                         </tr>
@@ -86,7 +93,7 @@
                     </div>
                     <hr />
                     <div ng-show="!!Req" ng-controller="HttpRequest">
-                        <h3>{{ Req.MethodPath }}</h3>
+                        <h3 class="wrapped">{{ Req.MethodPath }}</h3>
                         <div onbtnclick="replay()" btn="Replay" tabs="Summary,Headers,Raw,Binary">
                         </div>
 


### PR DESCRIPTION
## Solution
- Tested in latest versions of Chrome, Firefox, Safari.

The dashboard doesn't seem to work in IE at all -- I tested via browserstack. As such, the wrapping probably doesn't work in IE.

If IE should work, or is important to you, I can find a way to make it work.
## Chrome

![screen shot 2013-09-26 at 2 03 19 am](https://f.cloud.github.com/assets/49090/1215789/3203c526-2674-11e3-95b2-c2aa14871094.png)
## Firefox

![screen shot 2013-09-26 at 2 02 53 am](https://f.cloud.github.com/assets/49090/1215791/3a77795a-2674-11e3-975c-712d26006d12.png)
## Safari

![screen shot 2013-09-26 at 2 02 48 am](https://f.cloud.github.com/assets/49090/1215793/41d06dc4-2674-11e3-83e9-6819036163b6.png)

Should fix issue #29 
