### PR TITLE
Slightly better error message if you type ngrok with no args

### DIFF
--- a/src/ngrok/client/cli.go
+++ b/src/ngrok/client/cli.go
@@ -110,8 +110,8 @@ func parseArgs() (opts *Options, err error) {
 		os.Exit(0)
 	case "":
 		err = fmt.Errorf("Error: Specify a local port to tunnel to, or " +
-			"an ngrok command.\n\nExample: To expose port 5555, run " +
-			"'ngrok 5555'")
+			"an ngrok command.\n\nExample: To expose port 80, run " +
+			"'ngrok 80'")
 		return
 
 	default:


### PR DESCRIPTION
I wanted to do os.isatty for Go, to make it red if the user's printing to the terminal, but the closest I could find was http://godoc.org/code.google.com/p/go.crypto/ssh/terminal#IsTerminal and that was still reporting True if I redirected stdout to a file, so not sure whether that would work that well.

Anyway, this is an improvement on what is there currently
