### PR TITLE
Allow access to the ClientModel

### DIFF
--- a/src/ngrok/client/controller.go
+++ b/src/ngrok/client/controller.go
@@ -130,13 +130,29 @@ func (ctl *Controller) GetWebInspectAddr() string {
 	return ctl.config.InspectAddr
 }
 
+func (ctl *Controller) SetupModel(config *Configuration) *ClientModel {
+	model := newClientModel(config, ctl)
+	ctl.model = model
+	return model
+}
+
+func (ctl *Controller) GetModel() *ClientModel {
+	return ctl.model.(*ClientModel)
+}
+
 func (ctl *Controller) Run(config *Configuration) {
 	// Save the configuration
 	ctl.config = config
 
+	var model *ClientModel
+
+	if ctl.model == nil {
+		model = ctl.SetupModel(config)
+	} else {
+		model = ctl.model.(*ClientModel)
+	}
+
 	// init the model
-	model := newClientModel(config, ctl)
-	ctl.model = model
 	var state mvc.State = model
 
 	// init web ui


### PR DESCRIPTION
This lets the caller setup the ClientModel before Run is called.

I need this to get access to model.GetProtocols() to setup my own "HttpView-like" custom views.  By the time Run() gets called it's too late.
