### PR TITLE
Switch to gorilla/websocket

### DIFF
--- a/src/ngrok/client/views/web/view.go
+++ b/src/ngrok/client/views/web/view.go
@@ -2,7 +2,7 @@
 package web
 
 import (
-	"github.com/garyburd/go-websocket/websocket"
+	"github.com/gorilla/websocket"
 	"net/http"
 	"ngrok/client/assets"
 	"ngrok/client/mvc"
@@ -35,7 +35,7 @@ func NewWebView(ctl mvc.Controller, addr string) *WebView {
 
 	// handle web socket connections
 	http.HandleFunc("/_ws", func(w http.ResponseWriter, r *http.Request) {
-		conn, err := websocket.Upgrade(w, r.Header, nil, 1024, 1024)
+		conn, err := websocket.Upgrade(w, r, nil, 1024, 1024)
 
 		if err != nil {
 			http.Error(w, "Failed websocket upgrade", 400)
@@ -46,7 +46,7 @@ func NewWebView(ctl mvc.Controller, addr string) *WebView {
 		msgs := wv.wsMessages.Reg()
 		defer wv.wsMessages.UnReg(msgs)
 		for m := range msgs {
-			err := conn.WriteMessage(websocket.OpText, m.([]byte))
+			err := conn.WriteMessage(websocket.TextMessage, m.([]byte))
 			if err != nil {
 				// connection is closed
 				break


### PR DESCRIPTION
garyburd/go-websocket is marked as deprecated in favor of
gorilla/websocket. The changes are quite minimal.

This would close #77
