### PR TITLE
Fixed trust_host_root_certs adding InsecureSkipVerify: true in tls.Confi...

### DIFF
--- a/src/ngrok/client/model.go
+++ b/src/ngrok/client/model.go
@@ -102,7 +102,7 @@ func newClientModel(config *Configuration, ctl mvc.Controller) *ClientModel {
 	// configure TLS
 	if config.TrustHostRootCerts {
 		m.Info("Trusting host's root certificates")
-		m.tlsConfig = &tls.Config{}
+    m.tlsConfig = &tls.Config{ InsecureSkipVerify: true }
 	} else {
 		m.Info("Trusting root CAs: %v", rootCrtPaths)
 		var err error


### PR DESCRIPTION
Fixed trust_host_root_certs adding InsecureSkipVerify: true in tls.Config. This allows to use self-signed certificates without need for CA root certificate. In fact, without InsecureSkipVerify: true only works with trusted authorities certificates.
