### PR TITLE
client: add support for SHA-2

### DIFF
--- a/src/ngrok/client/tls.go
+++ b/src/ngrok/client/tls.go
@@ -1,6 +1,7 @@
 package client
 
 import (
+	_ "crypto/sha512"
 	"crypto/tls"
 	"crypto/x509"
 	"encoding/pem"


### PR DESCRIPTION
When using the client to connect to a self-hosted `ngrokd` that's using a leaf or intermediate certificate with a SHA-2 hash a `Failed to read message: remote error: bad certificate` is received by the server.

This is because SHA-2 isn't in `crypto/x509` this PR remedies that.

Further detail on this is here:
http://bridge.grumpy-troll.org/2014/05/golang-tls-comodo/
https://groups.google.com/forum/#!topic/Golang-nuts/hqm_ssUNUtI

I just had a certificate issued that triggers this issue - coincidentally a Comodo Positive SSL.
