### PR TITLE
Decrease length of default URLs

### DIFF
--- a/src/ngrok/server/tunnel.go
+++ b/src/ngrok/server/tunnel.go
@@ -86,7 +86,7 @@ func registerVhost(t *Tunnel, protocol string, servingPort int) (err error) {
 
 	// Register for random URL
 	t.url, err = tunnelRegistry.RegisterRepeat(func() string {
-		return fmt.Sprintf("%s://%x.%s", protocol, rand.Int31(), vhost)
+		return fmt.Sprintf("%s://%s.%s", protocol, RandomChars(5), vhost)
 	}, t)
 
 	return

--- a/src/ngrok/util/tunnel.go
+++ b/src/ngrok/util/tunnel.go
@@ -1,0 +1,18 @@
+package util
+
+import (
+	"time"
+	mrand "math/rand"
+)
+
+// Generate n random characters for use in URLs
+func RandomChars(n int) string {
+  mrand.Seed(time.Now().UnixNano())
+  var chars = []rune("0123456789abcdefghijklmnopqrstuvwxyz")
+  bytes := make([]rune, n)
+  for i := range bytes {
+    bytes[i] = chars[mrand.Intn(len(chars))]
+  }
+  return string(bytes)
+}
+


### PR DESCRIPTION
As discussed in Issue #277 this replaces default URLs of the form:

```
68425551.ngrok.io
```

with URLs of the form:

```
a92F.ngrok.io
```

when no subdomain is specified.

This still provides more than 14 million possible values, and is easier to remember/quicker to type.  Please let me know if you have any comments!
