### PR TITLE
added an api for tunnels

### DIFF
--- a/src/ngrok/client/views/web/http.go
+++ b/src/ngrok/client/views/web/http.go
@@ -263,6 +263,18 @@ func (whv *WebHttpView) register() {
 			panic(err)
 		}
 	})
+
+	http.HandleFunc("/api/tunnels", func(w http.ResponseWriter, r *http.Request) {
+		payloadData := whv.ctl.State().GetTunnels();
+
+		payload, err := json.Marshal(payloadData)
+		if err != nil {
+			panic(err)
+		}
+
+		w.Header().Set("Content-Type", "application/json");
+		w.Write(payload);
+	})
 }
 
 func (whv *WebHttpView) Shutdown() {


### PR DESCRIPTION
ngrok v2 has an /api/tunnels endpoint, it would be nice to have it in a simplistic form in the v1 (although not backwards compatible).  I can certainly work on making it more like the v2 but simply translating the tunnels object and calling it a day works well for me.