### PR TITLE
Support auth tokens from a file...

### DIFF
--- a/src/ngrok/server/cli.go
+++ b/src/ngrok/server/cli.go
@@ -11,6 +11,7 @@ type Options struct {
 	domain     string
 	tlsCrt     string
 	tlsKey     string
+	authTokens string
 	logto      string
 	loglevel   string
 }
@@ -22,6 +23,7 @@ func parseArgs() *Options {
 	domain := flag.String("domain", "ngrok.com", "Domain where the tunnels are hosted")
 	tlsCrt := flag.String("tlsCrt", "", "Path to a TLS certificate file")
 	tlsKey := flag.String("tlsKey", "", "Path to a TLS key file")
+	authTokens := flag.String("authTokens", "", "Path to an auth tokens file, empty string to disable")
 	logto := flag.String("log", "stdout", "Write log messages to this file. 'stdout' and 'none' have special meanings")
 	loglevel := flag.String("log-level", "DEBUG", "The level of messages to log. One of: DEBUG, INFO, WARNING, ERROR")
 	flag.Parse()
@@ -33,6 +35,7 @@ func parseArgs() *Options {
 		domain:     *domain,
 		tlsCrt:     *tlsCrt,
 		tlsKey:     *tlsKey,
+		authTokens: *authTokens,
 		logto:      *logto,
 		loglevel:   *loglevel,
 	}


### PR DESCRIPTION
Server loads valid auth tokens from an optional file passed in
via -authTokens. If no file is given, no checking is performed,
i.e. all auth tokens are valid. A missing auth tokens file is
the same as a deny all policy. The file is (re-)read upon each
new connection so it can be modified without restarting ngrokd.
The file is split up on all whitespace for tokens.

Example (contains four tokens):
	token1
	token2

	token3 token4