### PR TITLE
bugfix/proto default port in host header

### DIFF
--- a/src/ngrok/server/http.go
+++ b/src/ngrok/server/http.go
@@ -78,6 +78,16 @@ func httpHandler(c conn.Conn, proto string) {
 
 	// read out the Host header and auth from the request
 	host := strings.ToLower(vhostConn.Host())
+
+	// try fix Host header with default port
+	if (strings.Contains(host, ":")) {
+		// Host header contains a port number
+		parts := strings.Split(host, ":")
+		if ((proto == "http" && parts[1] == "80") || (proto == "https" && parts[1] == "443")) {
+			host = parts[0]
+		}
+	}
+
 	auth := vhostConn.Request.Header.Get("Authorization")
 
 	// done reading mux data, free up the request memory

--- a/src/ngrok/server/http.go
+++ b/src/ngrok/server/http.go
@@ -80,10 +80,10 @@ func httpHandler(c conn.Conn, proto string) {
 	host := strings.ToLower(vhostConn.Host())
 
 	// try fix Host header with default port
-	if (strings.Contains(host, ":")) {
+	if strings.Contains(host, ":") {
 		// Host header contains a port number
 		parts := strings.Split(host, ":")
-		if ((proto == "http" && parts[1] == "80") || (proto == "https" && parts[1] == "443")) {
+		if (proto == "http" && parts[1] == "80") || (proto == "https" && parts[1] == "443") {
 			host = parts[0]
 		}
 	}


### PR DESCRIPTION
fix tunnel searching with Host header contains a proto default port.

Issue: https://github.com/inconshreveable/ngrok/issues/298 #298